### PR TITLE
feat(snap): use updated environment variable injection

### DIFF
--- a/snap/local/hooks/cmd/configure/configure.go
+++ b/snap/local/hooks/cmd/configure/configure.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 
 	hooks "github.com/canonical/edgex-snap-hooks/v2"
+	"github.com/canonical/edgex-snap-hooks/v2/log"
+	"github.com/canonical/edgex-snap-hooks/v2/options"
 	local "github.com/edgexfoundry/device-mqtt-go/hooks"
 )
 
@@ -97,6 +99,12 @@ func main() {
 		// no action necessary
 	default:
 		hooks.Error(fmt.Sprintf("Invalid value for 'autostart' : %s", autostart))
+		os.Exit(1)
+	}
+
+	log.SetComponentName("configure")
+	if err := options.ProcessAppConfig("device-mqtt"); err != nil {
+		hooks.Error(fmt.Sprintf("could not process options: %v", err))
 		os.Exit(1)
 	}
 }

--- a/snap/local/hooks/cmd/configure/configure.go
+++ b/snap/local/hooks/cmd/configure/configure.go
@@ -51,6 +51,12 @@ func main() {
 
 	}
 
+	log.SetComponentName("configure")
+	if err := options.ProcessAppConfig("device-mqtt"); err != nil {
+		hooks.Error(fmt.Sprintf("could not process options: %v", err))
+		os.Exit(1)
+	}
+
 	// read env var override configuration
 	envJSON, err = cli.Config(hooks.EnvConfig)
 	if err != nil {
@@ -99,12 +105,6 @@ func main() {
 		// no action necessary
 	default:
 		hooks.Error(fmt.Sprintf("Invalid value for 'autostart' : %s", autostart))
-		os.Exit(1)
-	}
-
-	log.SetComponentName("configure")
-	if err := options.ProcessAppConfig("device-mqtt"); err != nil {
-		hooks.Error(fmt.Sprintf("could not process options: %v", err))
 		os.Exit(1)
 	}
 }

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -3,3 +3,5 @@ module github.com/edgexfoundry/device-mqtt-go/hooks
 require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220420075917-7fdbcd41ba0b
 
 go 1.17
+
+replace github.com/canonical/edgex-snap-hooks/v2 => github.com/farshidtz/edgex-snap-hooks/v2 v2.0.6-0.20220422071606-d43ccc771100

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,5 +1,5 @@
 module github.com/edgexfoundry/device-mqtt-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220414132045-1995f6204f7e
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220420075917-7fdbcd41ba0b
 
 go 1.17

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,7 +1,5 @@
 module github.com/edgexfoundry/device-mqtt-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220420075917-7fdbcd41ba0b
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3
 
 go 1.17
-
-replace github.com/canonical/edgex-snap-hooks/v2 => github.com/farshidtz/edgex-snap-hooks/v2 v2.0.6-0.20220422071606-d43ccc771100

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,5 +1,5 @@
 module github.com/edgexfoundry/device-mqtt-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.5
 
 go 1.17

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,5 +1,5 @@
 module github.com/edgexfoundry/device-mqtt-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.0.7
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220414132045-1995f6204f7e
 
 go 1.17

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3 h1:kQ7tGjA7k6iAfsvLRKpdoLy0zwsG+4Wqn3DNkbJrhZ8=
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.5 h1:EDFjmHy8CG4T8uFPqD+Per8Hgk250PvRsMgEDCXjYtE=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.5/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,7 +1,7 @@
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3 h1:kQ7tGjA7k6iAfsvLRKpdoLy0zwsG+4Wqn3DNkbJrhZ8=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/farshidtz/edgex-snap-hooks/v2 v2.0.6-0.20220422071606-d43ccc771100 h1:LpQTdrArglZpFxKC7o8WcddLoAeO4CBt32DyeVHtGys=
-github.com/farshidtz/edgex-snap-hooks/v2 v2.0.6-0.20220422071606-d43ccc771100/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,7 +1,7 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220420075917-7fdbcd41ba0b h1:vKrKzgdZo3kk0mptvQ1vvUUUQ2eYjE+nDMhT2tC9UJw=
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220420075917-7fdbcd41ba0b/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/farshidtz/edgex-snap-hooks/v2 v2.0.6-0.20220422071606-d43ccc771100 h1:LpQTdrArglZpFxKC7o8WcddLoAeO4CBt32DyeVHtGys=
+github.com/farshidtz/edgex-snap-hooks/v2 v2.0.6-0.20220422071606-d43ccc771100/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220414132045-1995f6204f7e h1:T2EXP6GuRQ/kiACRsrtInF3HXjinpU5DzETxEfUxIG4=
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220414132045-1995f6204f7e/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220420075917-7fdbcd41ba0b h1:vKrKzgdZo3kk0mptvQ1vvUUUQ2eYjE+nDMhT2tC9UJw=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220420075917-7fdbcd41ba0b/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.0.7 h1:R3a8PfMffUYJsY8uw7Rosu/KURkB55tTuO8YwETV5zY=
-github.com/canonical/edgex-snap-hooks/v2 v2.0.7/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220414132045-1995f6204f7e h1:T2EXP6GuRQ/kiACRsrtInF3HXjinpU5DzETxEfUxIG4=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220414132045-1995f6204f7e/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
1. setup:
```
go: downloading github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2.0.20220420075917-7fdbcd41ba0b
...
snap install edgexfoundry 
snapcraft
snap install edgex-device-mqtt_2.2.0-dev.15_amd64.snap --devmode
snap connect edgexfoundry:edgex-secretstore-token edgex-device-mqtt:edgex-secretstore-token
snap get edgex-device-mqtt -d
```
```json
{
	"lastrev": "x1",
	"release": "ireland"
}

```
2. use the legacy env. prefix:
```
$ snap set edgex-device-mqtt env.service.port=3000
$ cat /var/snap/edgex-device-mqtt/current/config/device-mqtt/res/device-mqtt.env
export SERVICE_PORT=3000
$ snap get edgex-device-mqtt -d
```
```json
{
	"env": {
		"service": {
			"port": 3000
		}
	},
	"lastrev": "x1",
	"release": "ireland"
}

```
3. set an apps. or config. option:
```
$ snap set edgex-device-mqtt apps.device-mqtt.config.service.port=2000
error: cannot perform the following tasks:
- Run configure hook of "edgex-device-mqtt" snap (run hook "configure": 
-----
edgex-device-mqtt.configure: could not process options: 'config.' and 'app.' options must not be mixed with legacy 'env.' options: {
	"service": {
		"port": 3000
	}
}
-----)
$ cat /var/snap/edgex-device-mqtt/current/config/device-mqtt/res/device-mqtt.env
export SERVICE_PORT=3000

$ snap stop edgex-device-mqtt
$ snap unset edgex-device-mqtt env
$ snap set edgex-device-mqtt apps.device-mqtt.config.service.port=2000
$ snap set edgex-device-mqtt config.service.port=1000
$ cat /var/snap/edgex-device-mqtt/current/config/device-mqtt/res/device-mqtt.env
export SERVICE_PORT=1000
export SERVICE_PORT=2000
$ snap get edgex-device-mqtt -d
```
```json
{
	"apps": {
		"device-mqtt": {
			"config": {
				"service": {
					"port": 2000
				}
			}
		}
	},
	"config": {
		"service": {
			"port": 1000
		}
	},
	"env": {}
}
```
```
$ snap start edgex-device-mqtt
msg="Web server starting (localhost:2000)"
```
4. unset <snap> env and validate it:
```
$ snap stop edgex-device-mqtt
$ snap unset edgex-device-mqtt config.service.port
$ snap unset edgex-device-mqtt apps.device-mqtt.config.service.port
$ snap get edgex-device-mqtt -d
```
```json
{
	"apps": {
		"device-mqtt": {
			"config": {
				"service": {}
			}
		}
	},
	"config": {
		"service": {}
	},
	"lastrev": "x1",
	"release": "ireland"
}
```
5.1 use a combination of apps. and config. for the same option:
```
$ snap stop edgex-device-mqtt
$ snap set edgex-device-mqtt apps.device-mqtt.config.service.port=5000
$ snap set edgex-device-mqtt config.service.port=5000
$ snap get edgex-device-mqtt -d
```
```json
{
	"apps": {
		"device-mqtt": {
			"config": {
				"service": {
					"port": 5000
				}
			}
		}
	},
	"config": {
		"service": {
			"port": 5000
		}
	},
	"lastrev": "x1",
	"release": "ireland"
}
```
```
$ snap start edgex-device-mqtt
msg="Web server starting (localhost:5000)"
```
5.2 use a combination of apps. and config. for different options:
```
$ snap stop edgex-device-mqtt
$ snap set edgex-device-mqtt config.service.port=5000
$ snap set edgex-device-mqtt apps.device-mqtt.config.service.port=6000
$ cat /var/snap/edgex-device-mqtt/current/config/device-mqtt/res/device-mqtt.env
export SERVICE_PORT=5000
export SERVICE_PORT=6000
$ snap start edgex-device-mqtt
msg="Web server starting (localhost:6000)"
```